### PR TITLE
Remove connection logs to avoid recursive stack when using the database as the log store

### DIFF
--- a/src/Database/MySqlConnector.php
+++ b/src/Database/MySqlConnector.php
@@ -43,15 +43,11 @@ class MySqlConnector extends DefaultMySqlConnector
         $token_provider = new RDSTokenProvider($config);
         try {
             $password = $token_provider->getToken();
-            Log::debug('Connecting to db using IAM authentication');
-
             return $this->createPdoConnection(
                 $dsn, $username, $password, $options
             );
         } catch (Exception $e) {
             $password = $token_provider->getToken(true);
-            Log::debug('Connecting to db using IAM authentication');
-
             return $this->tryAgainIfCausedByLostConnectionOrBadToken(
                 $e, $dsn, $username, $password, $options
             );

--- a/src/Database/PostgresConnector.php
+++ b/src/Database/PostgresConnector.php
@@ -43,15 +43,11 @@ class PostgresConnector extends DefaultPostgresConnector
         $token_provider = new RDSTokenProvider($config);
         try {
             $password = $token_provider->getToken();
-            Log::info('Connecting to db using auth token '.$password);
-
             return $this->createPdoConnection(
                 $dsn, $username, $password, $options
             );
         } catch (Exception $e) {
             $password = $token_provider->getToken(true);
-            Log::info('Connecting to db using auth token '.$password);
-
             return $this->tryAgainIfCausedByLostConnectionOrBadToken(
                 $e, $dsn, $username, $password, $options
             );


### PR DESCRIPTION
This change removes log statements from both the PostgresConnector.php and MySqlConnector.php. Some frameworks and plugins use the database as their log store, so having a log statement in the connector code can cause a recursive stack.

Resolves #10 